### PR TITLE
Add script in ./utils/ to see a Board quickview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ vim trello-fields.json
 ```
 
 ```bash
+node ./utils/board-quickview.js
+```
+
+```bash
 node ./etl.js
 ```
 
@@ -112,6 +116,12 @@ example:
 
 ```bash
 mv ~/Downloads/FPJzDcok.json ./board.json
+```
+
+To take a quick look at the info on the board:
+
+```bash
+node ./utils/board-quickview.js
 ```
 
 ## `members.json`

--- a/etl.js
+++ b/etl.js
@@ -211,37 +211,8 @@ async function sleep(delay) {
 }
 
 async function main(board) {
-  /// begin transform
-  // transform between the old trello board.json and the new
-  let cardsMap = {};
+  board = Transform.trelloBoardUpgrade(board);
 
-  board.cards.forEach(function (card) {
-    cardsMap[card.id] = card;
-    // the new format doesn't have checklists
-    if (!card.checklists) {
-      card.checklists = [];
-      card._newChecklists = true;
-    }
-  });
-
-  if (board.checklists) {
-    board.checklists.forEach(function (checklist) {
-      let card = cardsMap[checklist.idCard];
-      if (card._newChecklists) {
-        card.checklists.push(checklist);
-      }
-    });
-  }
-
-  board.cards.forEach(function (card) {
-    // sort checklists by Trello sort order
-    card.checklists.sort(function (a, b) {
-      return a.pos - b.pos;
-    });
-  });
-
-  cardsMap = null;
-  /// end transform
   let testCard = board.cards[72];
   console.info("");
   console.info("###", testCard.checklists[0].checkItems[0].name);

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -203,3 +203,37 @@ Transform.trelloIdToUsername = function (id) {
   });
   return member.username;
 };
+
+Transform.trelloBoardUpgrade = function (board) {
+  // transform between the old trello board.json style and the new version
+  let cardsMap = {};
+
+  board.cards.forEach(function (card) {
+    cardsMap[card.id] = card;
+    // the new format doesn't have checklists
+    if (!card.checklists) {
+      card.checklists = [];
+      card._newChecklists = true;
+    }
+  });
+
+  if (board.checklists) {
+    board.checklists.forEach(function (checklist) {
+      let card = cardsMap[checklist.idCard];
+      if (card._newChecklists) {
+        card.checklists.push(checklist);
+      }
+    });
+  }
+
+  board.cards.forEach(function (card) {
+    // sort checklists by Trello sort order
+    card.checklists.sort(function (a, b) {
+      return a.pos - b.pos;
+    });
+  });
+
+  cardsMap = null;
+
+  return board;
+};

--- a/utils/board-quickview.js
+++ b/utils/board-quickview.js
@@ -1,0 +1,198 @@
+"use strict";
+
+let Transform = require("../lib/transform.js");
+
+let board = require("../board.json");
+board = Transform.trelloBoardUpgrade(board);
+
+//let members = board.members;
+let cards = board.cards;
+//let checklists = board.checklists;
+
+let trelloFields = require("../trello-fields.json");
+
+function grabDirtyFallbackOwner(card) {
+  let fallbackOwnerField = card.customFieldItems.find(function (field) {
+    return field.idCustomField === trelloFields.secondaryAdmin;
+  });
+
+  let fallbackOwner = fallbackOwnerField?.value?.text?.replace(/^@/, "");
+  return fallbackOwner;
+
+  /*
+  let fallbackOwnerId = "";
+  if (fallbackOwner) {
+    fallbackOwnerId = Transform.trelloUsernameToId(fallbackOwner);
+  }
+
+  return fallbackOwnerId;
+  */
+}
+
+console.info("");
+console.info("Trello board stuff...");
+console.info("");
+
+console.info("Columns (a.k.a. lists, a.k.a. Trello Types):");
+board.lists.forEach(function (list) {
+  console.info(`    ${list.name}`);
+});
+console.info("");
+
+console.info("Labels ('Meta' vs 'Paused', 'Completed':");
+board.labels.forEach(function (label) {
+  console.info(`    ${label.name}`);
+});
+console.info("");
+
+let actives = {
+  Members: {},
+  "Typoed Members": {},
+  Columns: {},
+  Labels: {},
+  Checklists: {},
+};
+
+console.info(
+  `| Trello ID | Issue Type | Card Type | Task Type | Owner | Owner 2 | Assignee | Labels |`
+);
+console.info(
+  `| --------- | ---------- | --------- | --------- | ----- | ------- | -------- | ------ |`
+);
+cards
+  //
+  //.slice(70, 80)
+  //
+  .forEach(function (card) {
+    if (card.closed) {
+      // skip closed card
+      return;
+    }
+
+    let list = board.lists.find(function (list) {
+      return list.id === card.idList;
+    });
+    card._trelloCardType = list.name;
+    actives.Columns[card._trelloCardType] = true;
+
+    let labels = card.labels.map(function (label) {
+      actives.Labels[label.name] = true;
+      return label.name;
+    });
+    if (!labels.length) {
+      labels.push("! No Label");
+    }
+
+    // Set Owner & Fallback Owner
+    card._members = card.idMembers.map(function (id) {
+      return Transform.trelloIdToUsername(id);
+    });
+    card.__fallbackOwner = grabDirtyFallbackOwner(card);
+    card._owner = card._members.find(function (m) {
+      // "riongull".match("samkirby") // null
+      // "samkirby22".match("samkirby") // ["samkirby22", "samkirby"]
+      if (!card.__fallbackOwner) {
+        return true;
+      }
+      return !m.toLowerCase().match(card.__fallbackOwner.toLowerCase());
+    });
+    if (!card._owner) {
+      card._owner = "! No Owner";
+    } else {
+      actives.Members[card._owner] = true;
+    }
+
+    // Set "clean" Fallback Owner
+    if (card.__fallbackOwner) {
+      card._fallbackOwner = card._members.find(function (m) {
+        // protect against similar names
+        // [ "sam", "samkirby" ]
+        if (card._owner) {
+          if (m.toLowerCase() === card._owner.toLowerCase()) {
+            return false;
+          }
+        }
+
+        // TODO  distinguish between perfect and similar matches?
+        return m.toLowerCase().match(card.__fallbackOwner.toLowerCase());
+      });
+      if (card._fallbackOwner) {
+        actives.Members[card._fallbackOwner] = true;
+      } else {
+        actives["Typoed Members"][card.__fallbackOwner] = true;
+      }
+    }
+    if (!card._fallbackOwner) {
+      card._fallbackOwner = "! No Fallback Owner";
+    }
+
+    console.info(
+      "|",
+      [
+        card.id,
+        "Card",
+        card._trelloCardType,
+        "-",
+        card._owner,
+        card._fallbackOwner || card.__fallbackOwner + "*",
+        "-",
+        labels.join(", "),
+      ].join("|"),
+      "|"
+    );
+
+    card.checklists.forEach(function (checklist) {
+      checklist.checkItems.forEach(function (item) {
+        if ("completed" === item.state) {
+          // skip completed tasks
+          return;
+        }
+
+        let taskType = checklist.name.replace(/\s*Tasks?\s*/, "") + " Task";
+        actives.Checklists[taskType] = true;
+
+        let member = "! Not Assigned";
+        if (item.idMember) {
+          member = Transform.trelloIdToUsername(item.idMember);
+          if (!member) {
+            console.warn(
+              `XXXX couldn't translate ${item.idMember} to member name`
+            );
+          }
+          actives.Members[member] = true;
+        }
+
+        console.info(
+          "|",
+          [
+            item.id,
+            "Task",
+            "-", //card._trelloCardType,
+            taskType,
+            "-", //card._owner,
+            "-", //card._fallbackOwner || card.__fallbackOwner + "*",
+            member,
+            "-", //labels.join(", ")
+          ].join("|"),
+          "|"
+        );
+      });
+    });
+  });
+
+console.info("");
+console.info("");
+
+Object.keys(actives).forEach(function (category) {
+  console.info(`## Active ${category}`);
+  console.info("");
+  let group = actives[category];
+  Object.keys(group)
+    .sort()
+    .forEach(function (name) {
+      console.info(`- ${name}`);
+    });
+  console.info("");
+});
+
+console.info("");

--- a/utils/board-quickview.js
+++ b/utils/board-quickview.js
@@ -50,6 +50,7 @@ let actives = {
   "Typoed Members": {},
   Columns: {},
   Labels: {},
+  "Custom Fields": {},
   Checklists: {},
 };
 
@@ -74,6 +75,13 @@ cards
     });
     card._trelloCardType = list.name;
     actives.Columns[card._trelloCardType] = true;
+
+    card.customFieldItems.forEach(function (field) {
+      let customField = board.customFields.find(function (cf) {
+        return field.idCustomField === cf.id;
+      });
+      actives["Custom Fields"][customField.name] = true;
+    });
 
     let labels = card.labels.map(function (label) {
       actives.Labels[label.name] = true;


### PR DESCRIPTION
Here's the data that can be found among all cards that are not `closed` and all tasks that are not `completed`:

# Example

The CLI util outputs valid Markdown. Here it be:

## Active Columns ("Trello Card Types")

- Completed
- Concepts
- Ideas
- Jobs
- Looking for Talent / Co-Founder
- Programmes
- Projects
- Services
- Specifications

## Active Custom Fields

- Completed
- Concept Doc
- Contact
- Last Phase
- Meta Bounty
- Paused
- Phase
- Rating
- Secondary Admin
- Source
- Website
- Work

## Active Labels

- Completed
- Meta
- Paused

## Active Checklists ("Trello Task Types")

- Concept Task
- Production Task
- QA Task
- Specification Task

## Active Members

- 10xcryptodev
- ackhia
- alanzhu94
- alexdcox
- antogiamba
- ashfrancis
- blockchaintech3
- burakbilen2
- byronappelt1
- cframossheesh
- christroutner
- cloudwheels
- coolaj86
- cowboy95
- dankrol
- dashameter
- davidzhen1
- deeayeen
- djelly
- doekekoedijk
- emmanueleclipse
- felixmago
- fengzie
- greatwolf_
- happyviki
- hilawe
- huntersides
- imestin
- izzycjr
- juancurti5
- kaisaitodev
- katew99
- kevin08953680
- kiddouglas
- kodaxx
- krasator
- lina_a
- marner
- maxpage6
- mayoreee
- mikhailpopov21
- monsieurbenji
- mrp226
- mvndaai
- obusco
- panzerknacker_inc
- pastapastapasta
- plan17b
- polo348
- quantumexplorer
- raphaeltant1
- riongull
- risanm
- samkirby22
- schlomo02
- scistone_
- shotonoff
- shumie
- spectaprod
- strophy
- teerplamak
- thedesertlynx
- timetodash
- wisdomogwu1
- wizlee3
- xandr_p

## Active Typoed Members

Fallback Owners that don't match an Owner

- andyfreer
- readme
- spectaprod